### PR TITLE
Wrap everything with an eval-when

### DIFF
--- a/defdata.lisp
+++ b/defdata.lisp
@@ -109,7 +109,7 @@ functions."
                 ,(when (plusp nfields)
                    `(write-char #\) ,stream)))))
       ;; Define everything.
-      `(progn
+      `(eval-when (:compile-toplevel :load-toplevel :execute)
          ;; Define the data type.
          (defstruct (,adt-name (:constructor nil)
                                (:copier nil)


### PR DESCRIPTION
In Clozure CL, the initial struct is not defined in time subsequent struct definitions. EVAL-WHEN makes it available in time.

This addresses issue #4.