### PR TITLE
basic do-notation.

### DIFF
--- a/cl-algebraic-data-type.asd
+++ b/cl-algebraic-data-type.asd
@@ -13,4 +13,5 @@
                (:file "package")
                (:file "utilities")
                (:file "defdata")
-               (:file "match")))
+               (:file "match")
+	       (:file "do-notation")))

--- a/do-notation.lisp
+++ b/do-notation.lisp
@@ -1,0 +1,13 @@
+;;;; do-notation.lisp
+;;;; Copyright (c) 2013 Robert Smith
+
+(in-package #:cl-algebraic-data-type)
+
+(defmacro do-notation (bind-function expressions &body body)
+  "Given a BIND-FUNCTION and all the bind expressions, evaluate BODY."
+  `(progn
+     ,@(reduce (lambda (acc do-binding)
+		 (append `((,bind-function (lambda (,(car do-binding)) ,@acc)
+					   ,@(cdr do-binding)))))
+	       (reverse expressions)
+	       :initial-value body)))

--- a/examples.lisp
+++ b/examples.lisp
@@ -14,6 +14,27 @@
     ((just x) x)
     (nothing else)))
 
+(defun bind-maybe (f m)
+  (match maybe m
+    ((just x) (funcall f x))
+    (nothing nothing)))
+
+(defun inc-maybe (x)
+  (just (1+ x)))
+
+(defun maybe->string (x)
+  (just (write-to-string x)))
+
+(string-equal "2" (do-notation bind-maybe
+                      ((sum (inc-maybe 1))
+                       (str (maybe->string sum)))
+                    str))
+
+(equal nothing (do-notation bind-maybe
+                   ((sum nothing)
+                    (str (maybe->string sum)))
+                 (print str)))
+
 
 ;;; Either
 
@@ -21,6 +42,26 @@
   (left t)
   (right t))
 
+(defun bind-either (f m)
+  (match either m
+    ((right x) (funcall f x))
+    ((left b) (left b))))
+
+(defun inc-either (x)
+  (right (1+ x)))
+
+(defun either->string (x)
+  (right (write-to-string x)))
+
+(string-equal "2" (do-notation bind-either
+                      ((sum (inc-either 1))
+                       (str (either->string sum)))
+                    str))
+
+(equalp (left 1) (do-notation bind-either
+                     ((sum (left 1))
+                      (str (either->string sum)))
+                   (print str)))
 
 ;;; Point
 


### PR DESCRIPTION
It's super helpful to have do notation simplify and organize code.

It works just like #'map version, where you can specify the result-type, but we give a bind function that will be used. 
If we get to the point where we can specify all the typeclasses, maybe we can remove the bind function argument.